### PR TITLE
improve style

### DIFF
--- a/SSJ_notebook.jl
+++ b/SSJ_notebook.jl
@@ -526,7 +526,7 @@ function get_steady_state(r_target,np::NumericalParameters)
 	#get distribution as (na × ns matrix)
 	D_ss = reshape(inv_dist(build_Λ(a_ss, np)),(na,ns))
 
-	return K_ss, L, w_ss, c_ss, a_ss, D_ss, np
+	return (; K_ss, L, w_ss, c_ss, a_ss, D_ss, np)
 end
 
 # ╔═╡ ce219259-f7a8-43e6-89d9-de8787644046
@@ -536,7 +536,7 @@ Now, lets get that steady state (and measure the time):
 
 # ╔═╡ 229f1996-3a93-43d2-8a65-b2e80ce6b12c
 #Now, lets get our steady state objects
-@time K_ss, L, w_ss, c_ss, a_ss, D_ss, np = 
+@time (; K_ss, L, w_ss, c_ss, a_ss, D_ss, np) = 
 	get_steady_state(0.01,NumericalParameters())
 
 # ╔═╡ 487056aa-2c18-45a6-b343-d7c467db7a68


### PR DESCRIPTION
Hi!

Here are some stylistic changes. I made these as I played with your notebook. So I thought I might as well share them with you.

No hard feeling, if you just ignore this PR.

1. the `@unpack` and `@with_kw` macros are now unnecessary in recent julia versions
2. I added a `TableOfContents()` to the Pluto notebooks
3. `using QuantEcon: rouwenhorst` instead of copy-pasting
4. load packages in the "Appendix" 

<details> <summary> screen shot for 2, 3, 4</summary> 

<img width="1279" alt="image" src="https://github.com/mhaense1/SSJ_Julia_Notebook/assets/6280307/2c953568-165b-449b-a96f-b01c5fedb44e">

</details>

5. I removed some unnecessary `begin ... end` blocks
6. putting a string just before a function definition is a _doc string_. If you add it, then it will automatically show up in the Pluto documentation. 

<details> <summary> screen shot </summary> 

<img width="1289" alt="image" src="https://github.com/mhaense1/SSJ_Julia_Notebook/assets/6280307/a5c4abd0-f70f-47f9-9534-df70f45ddada">

 </details>


